### PR TITLE
Dockerbuild für arm64 fixen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3-alpine
 
+RUN apk add zlib-dev jpeg-dev gcc musl-dev
+
 WORKDIR /app
 
 RUN pip install pipenv


### PR DESCRIPTION
Bei dem Alpine Docker image für arm64 scheinen ein paar Pakete nicht installiert zu sein.